### PR TITLE
Make default TAR_PREFIX more reasonable

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -21,5 +21,5 @@ setvar USE_CACHED_RPXC    0
 setvar GATEWAY_REPO       https://github.com/mozilla-iot/gateway
 setvar GATEWAY_BRANCH     master
 setvar OPENZWAVE_ZIP      https://codeload.github.com/OpenZWave/open-zwave/zip/ab5fe966fee882bb9e8d78a91db892a60a1863d9
-setvar TAR_PREFIX         0.5.1-pre1
+setvar TAR_PREFIX         ${GATEWAY_BRANCH}
 echo "==================================================================================="


### PR DESCRIPTION
Make the TAR_PREFIX default to being the GATEWAY_BRANCH